### PR TITLE
Use absolute template paths for dashboard

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -6,6 +6,7 @@ from flask import Flask, render_template, jsonify, request, send_file
 from flask_socketio import SocketIO, emit
 import json
 import os
+from pathlib import Path
 from datetime import datetime
 import pandas as pd
 import plotly.graph_objs as go
@@ -14,8 +15,8 @@ import time
 import sys
 import threading
 
-# --- Templates dir ---
-os.makedirs("templates", exist_ok=True)
+# --- Paths ---
+BASE_DIR = Path(__file__).resolve().parent
 
 # --- Imports & logger fallback ---
 import logging
@@ -40,7 +41,7 @@ except ImportError as e:
         sys.exit(1)
 
 # --- Flask / SocketIO ---
-app = Flask(__name__)
+app = Flask(__name__, template_folder=str(BASE_DIR / "templates"))
 app.config['SECRET_KEY'] = 'algo_trading_secret_key_2024'
 
 # Force threading backend to avoid eventlet/gevent mismatches unless you explicitly install/configure them.
@@ -222,10 +223,10 @@ def create_hourly_performance_chart():
 @app.route('/')
 def dashboard():
     """Main dashboard page"""
-    template_path = os.path.join('templates', 'dashboard.html')
-    if not os.path.exists(template_path):
-        os.makedirs('templates', exist_ok=True)
-        with open(template_path, 'w', encoding='utf-8') as f:
+    template_path = BASE_DIR / "templates" / "dashboard.html"
+    if not template_path.exists():
+        template_path.parent.mkdir(parents=True, exist_ok=True)
+        with template_path.open('w', encoding='utf-8') as f:
             f.write(get_dashboard_html())
     try:
         return render_template('dashboard.html')


### PR DESCRIPTION
## Summary
- define a BASE_DIR constant and configure Flask to look for templates under that absolute path
- update the dashboard route to read and create dashboard.html relative to BASE_DIR instead of the current working directory

## Testing
- python -m compileall dashboard_app.py

------
https://chatgpt.com/codex/tasks/task_e_68c84510fae8832b9404e2d07ba96305